### PR TITLE
Add playlist auto-continue option

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/data/DeviceClasses.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/data/DeviceClasses.kt
@@ -132,6 +132,7 @@ data class DeviceSettings(
   var autoSleepTimerEndTime: String,
   var autoSleepTimerAutoRewind: Boolean,
   var autoSleepTimerAutoRewindTime: Long, //Time in milliseconds
+  var autoContinuePlaylists: Boolean,
   var sleepTimerLength: Long, // Time in milliseconds
   var disableSleepTimerFadeOut: Boolean,
   var disableSleepTimerResetFeedback: Boolean,
@@ -159,9 +160,10 @@ data class DeviceSettings(
         autoSleepTimer = false,
         autoSleepTimerStartTime = "22:00",
         autoSleepTimerEndTime = "06:00",
-        sleepTimerLength = 900000L, // 15 minutes
         autoSleepTimerAutoRewind = false,
         autoSleepTimerAutoRewindTime = 300000L, // 5 minutes
+        autoContinuePlaylists = false,
+        sleepTimerLength = 900000L, // 15 minutes
         disableSleepTimerFadeOut = false,
         disableSleepTimerResetFeedback = false,
         enableSleepTimerAlmostDoneChime = false,

--- a/components/app/AudioPlayer.vue
+++ b/components/app/AudioPlayer.vue
@@ -833,6 +833,7 @@ export default {
 
       if (data.playerState === 'ENDED') {
         console.log('[AudioPlayer] Playback ended')
+        this.$eventBus.$emit('playback-ended')
       }
       this.isEnded = data.playerState === 'ENDED'
 

--- a/ios/App/App/plugins/AbsDatabase.swift
+++ b/ios/App/App/plugins/AbsDatabase.swift
@@ -267,6 +267,7 @@ public class AbsDatabase: CAPPlugin, CAPBridgedPlugin {
         let downloadUsingCellular = call.getString("downloadUsingCellular") ?? "ALWAYS"
         let streamingUsingCellular = call.getString("streamingUsingCellular") ?? "ALWAYS"
         let disableSleepTimerFadeOut = call.getBool("disableSleepTimerFadeOut") ?? false
+        let autoContinuePlaylists = call.getBool("autoContinuePlaylists") ?? false
         let settings = DeviceSettings()
         settings.disableAutoRewind = disableAutoRewind
         settings.enableAltView = enableAltView
@@ -279,6 +280,7 @@ public class AbsDatabase: CAPPlugin, CAPBridgedPlugin {
         settings.downloadUsingCellular = downloadUsingCellular
         settings.streamingUsingCellular = streamingUsingCellular
         settings.disableSleepTimerFadeOut = disableSleepTimerFadeOut
+        settings.autoContinuePlaylists = autoContinuePlaylists
 
         Database.shared.setDeviceSettings(deviceSettings: settings)
 

--- a/ios/App/Shared/models/DeviceSettings.swift
+++ b/ios/App/Shared/models/DeviceSettings.swift
@@ -20,6 +20,7 @@ class DeviceSettings: Object {
     @Persisted var downloadUsingCellular: String = "ALWAYS"
     @Persisted var streamingUsingCellular: String = "ALWAYS"
     @Persisted var disableSleepTimerFadeOut: Bool = false
+    @Persisted var autoContinuePlaylists: Bool = false
 }
 
 func getDefaultDeviceSettings() -> DeviceSettings {
@@ -38,6 +39,7 @@ func deviceSettingsToJSON(settings: DeviceSettings) -> Dictionary<String, Any> {
         "languageCode": settings.languageCode,
         "downloadUsingCellular": settings.downloadUsingCellular,
         "streamingUsingCellular": settings.streamingUsingCellular,
-        "disableSleepTimerFadeOut": settings.disableSleepTimerFadeOut
+        "disableSleepTimerFadeOut": settings.disableSleepTimerFadeOut,
+        "autoContinuePlaylists": settings.autoContinuePlaylists
     ]
 }

--- a/pages/playlist/_id.vue
+++ b/pages/playlist/_id.vue
@@ -110,6 +110,9 @@ export default {
         return this.$store.getters['getIsMediaStreaming'](i.libraryItemId, i.episodeId)
       })
     },
+    autoContinuePlaylists() {
+      return this.$store.state.deviceData?.deviceSettings?.autoContinuePlaylists
+    },
     showPlayButton() {
       return this.playableItems.length
     },
@@ -154,6 +157,11 @@ export default {
         }
       }
     },
+    onPlaybackEnded() {
+      if (this.autoContinuePlaylists && this.isOpenInPlayer) {
+        this.playNextItem()
+      }
+    },
     playlistUpdated(playlist) {
       if (this.playlist.id !== playlist.id) return
       this.playlist = playlist
@@ -167,10 +175,12 @@ export default {
   mounted() {
     this.$socket.$on('playlist_updated', this.playlistUpdated)
     this.$socket.$on('playlist_removed', this.playlistRemoved)
+    this.$eventBus.$on('playback-ended', this.onPlaybackEnded)
   },
   beforeDestroy() {
     this.$socket.$off('playlist_updated', this.playlistUpdated)
     this.$socket.$off('playlist_removed', this.playlistRemoved)
+    this.$eventBus.$off('playback-ended', this.onPlaybackEnded)
   }
 }
 </script>

--- a/pages/settings.vue
+++ b/pages/settings.vue
@@ -67,6 +67,12 @@
       </div>
       <p class="pl-4">{{ $strings.LabelAllowSeekingOnMediaControls }}</p>
     </div>
+    <div class="flex items-center py-3">
+      <div class="w-10 flex justify-center" @click="toggleAutoContinuePlaylists">
+        <ui-toggle-switch v-model="settings.autoContinuePlaylists" @input="saveSettings" />
+      </div>
+      <p class="pl-4">{{ $strings.LabelAutoContinuePlaylists }}</p>
+    </div>
 
     <!-- Sleep timer settings -->
     <template v-if="!isiOS">
@@ -215,6 +221,7 @@ export default {
         disableSleepTimerFadeOut: false,
         disableSleepTimerResetFeedback: false,
         enableSleepTimerAlmostDoneChime: false,
+        autoContinuePlaylists: false,
         autoSleepTimerAutoRewind: false,
         autoSleepTimerAutoRewindTime: 300000, // 5 minutes
         languageCode: 'en-us',
@@ -577,6 +584,10 @@ export default {
       this.settings.allowSeekingOnMediaControls = !this.settings.allowSeekingOnMediaControls
       this.saveSettings()
     },
+    toggleAutoContinuePlaylists() {
+      this.settings.autoContinuePlaylists = !this.settings.autoContinuePlaylists
+      this.saveSettings()
+    },
     getCurrentOrientation() {
       const orientation = window.screen?.orientation || {}
       const type = orientation.type || ''
@@ -638,6 +649,7 @@ export default {
       this.settings.disableSleepTimerResetFeedback = !!deviceSettings.disableSleepTimerResetFeedback
       this.settings.enableSleepTimerAlmostDoneChime = !!deviceSettings.enableSleepTimerAlmostDoneChime
 
+      this.settings.autoContinuePlaylists = !!deviceSettings.autoContinuePlaylists
       this.settings.autoSleepTimerAutoRewind = !!deviceSettings.autoSleepTimerAutoRewind
       this.settings.autoSleepTimerAutoRewindTime = !isNaN(deviceSettings.autoSleepTimerAutoRewindTime) ? deviceSettings.autoSleepTimerAutoRewindTime : 300000 // 5 minutes
 

--- a/strings/en-us.json
+++ b/strings/en-us.json
@@ -112,6 +112,7 @@
   "LabelAutoSleepTimerAutoRewind": "Auto sleep timer auto rewind",
   "LabelAutoSleepTimerAutoRewindHelp": "When the auto sleep timer finishes, playing the item again will automatically rewind your position.",
   "LabelAutoSleepTimerHelp": "When playing media between the specified start and end times a sleep timer will automatically start.",
+  "LabelAutoContinuePlaylists": "Auto continue playlists",
   "LabelBooks": "Books",
   "LabelChapterTrack": "Chapter Track",
   "LabelChapters": "Chapters",


### PR DESCRIPTION
## Summary
- allow playlists to auto-play the next item
- expose auto-continue toggle in Settings
- emit `playback-ended` event from player
- listen for `playback-ended` on playlist page
- support new setting in native models

## Testing
- `git diff --check`

------
https://chatgpt.com/codex/tasks/task_e_68825755407883208550631a08d6abc2