### PR TITLE
Fix download queue clearing

### DIFF
--- a/components/tables/podcast/EpisodesTable.vue
+++ b/components/tables/podcast/EpisodesTable.vue
@@ -237,7 +237,7 @@ export default {
           .get(`/api/podcasts/${this.libraryItemId}/clear-queue`)
           .then(() => {
             this.$toast.success('Episode download queue cleared')
-            this.episodeDownloadQueued = []
+            this.episodeDownloadsQueued = []
           })
           .catch((error) => {
             console.error('Failed to clear queue', error)


### PR DESCRIPTION
## Summary
- fix queue array cleared after successful request

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68825bcd57408320bf9cfbb60d4b9fa6