### PR TITLE
Improve Android progress sync

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/media/MediaProgressSyncer.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/media/MediaProgressSyncer.kt
@@ -30,7 +30,9 @@ class MediaProgressSyncer(
         private val apiHandler: ApiHandler
 ) {
   private val tag = "MediaProgressSync"
-  private val METERED_CONNECTION_SYNC_INTERVAL = 60000
+  // Default sync interval when on a metered network. Reduced from 60s so
+  // progress updates happen sooner when auto continuing playback.
+  private val METERED_CONNECTION_SYNC_INTERVAL = 30000
 
   private var listeningTimerTask: TimerTask? = null
   var listeningTimerRunning: Boolean = false
@@ -75,8 +77,10 @@ class MediaProgressSyncer(
             "start: init last sync time $lastSyncTime with playback session id=${currentPlaybackSession?.id}"
     )
 
+    // Sync progress more frequently to improve responsiveness when
+    // auto continuing playback.
     listeningTimerTask =
-            Timer("ListeningTimer", false).schedule(15000L, 15000L) {
+            Timer("ListeningTimer", false).schedule(5000L, 5000L) {
               Handler(Looper.getMainLooper()).post() {
                 if (playerNotificationService.currentPlayer.isPlaying) {
                   // Set auto sleep timer if enabled and within start/end time

--- a/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
@@ -615,13 +615,12 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
 
   fun handlePlaybackEnded() {
     Log.d(tag, "handlePlaybackEnded")
-    if (isAndroidAuto && currentPlaybackSession?.isPodcastEpisode == true) {
-      Log.d(tag, "Podcast playback ended on android auto")
-      val libraryItem = currentPlaybackSession?.libraryItem ?: return
+    val afterSync = afterSync@{
+      if (isAndroidAuto && currentPlaybackSession?.isPodcastEpisode == true) {
+        Log.d(tag, "Podcast playback ended on android auto")
+        val libraryItem = currentPlaybackSession?.libraryItem ?: return@afterSync
 
-      // Need to sync with server to set as finished
-      mediaProgressSyncer.finished {
-        // Need to reload media progress
+        // Need to reload media progress then start next episode
         mediaManager.loadServerUserMediaProgress {
           val podcast = libraryItem.media as Podcast
           val nextEpisode = podcast.getNextUnfinishedEpisode(libraryItem.id, mediaManager)
@@ -639,6 +638,10 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
         }
       }
     }
+
+    // Always send a final progress sync when playback ends so the next item can
+    // start with the most up-to-date progress.
+    mediaProgressSyncer.finished(afterSync)
   }
 
   fun startNewPlaybackSession() {


### PR DESCRIPTION
## Summary
- speed up progress sync timer to 5s
- sync progress at the end of playback so auto-continue sees the latest progress
- fix lambda label for playback end sync

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68827b5a833c8320a3c86653d22fce15