### PR TITLE
Fix auto download after library load

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -206,6 +206,8 @@ export default {
 
       AbsLogger.info({ tag: 'default', message: `initLibraries loading library ${this.currentLibraryName}` })
       await this.$store.dispatch('libraries/fetch', this.currentLibraryId)
+      // Run auto download check now that libraries are loaded
+      await this.$store.dispatch('autoDownloadCheck')
       this.$eventBus.$emit('library-changed')
       this.inittingLibraries = false
     },


### PR DESCRIPTION
## Summary
- trigger auto download check once libraries are loaded

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688a6e2c4e0c83208a2e334de57355b6