### PR TITLE
fix: restore web cast button

### DIFF
--- a/plugins/capacitor/AbsAudioPlayer.js
+++ b/plugins/capacitor/AbsAudioPlayer.js
@@ -18,6 +18,25 @@ class AbsAudioPlayerWeb extends WebPlugin {
     this.audioTracks = []
     this.startTime = 0
     this.trackStartTime = 0
+
+    this.castAvailable = false
+
+    if (typeof window !== 'undefined') {
+      // Called by the cast framework once it loads
+      window.__onGCastApiAvailable = (isAvailable) => {
+        this.castAvailable =
+          !!isAvailable &&
+          !!(window.chrome?.cast?.isAvailable || window.cast?.framework)
+        this.notifyListeners('onCastAvailableUpdate', {
+          value: this.castAvailable
+        })
+      }
+
+      // Check immediately in case the API is already available
+      this.castAvailable = !!(
+        window.chrome?.cast?.isAvailable || window.cast?.framework
+      )
+    }
   }
 
   // Use startTime to find current track index
@@ -168,7 +187,7 @@ class AbsAudioPlayerWeb extends WebPlugin {
 
   // PluginMethod
   async getIsCastAvailable() {
-    return false
+    return { value: this.castAvailable }
   }
 
   initializePlayer() {


### PR DESCRIPTION
## Summary
- restore Google Cast detection on web player to show Cast button

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688b876415d4832088437918927ed692