### PR TITLE
Handle skip key events and always enable seek

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/data/PlaybackSession.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/data/PlaybackSession.kt
@@ -224,6 +224,8 @@ class PlaybackSession(
                             coverUri.toString()
                     )
 
+    metadataBuilder.putLong(MediaMetadataCompat.METADATA_KEY_DURATION, totalDurationMs)
+
     // Local covers get bitmap
     if (localLibraryItem?.coverContentUrl != null) {
       val bitmap =

--- a/android/app/src/main/java/com/audiobookshelf/app/player/MediaSessionCallback.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/MediaSessionCallback.kt
@@ -199,6 +199,14 @@ class MediaSessionCallback(var playerNotificationService:PlayerNotificationServi
             Log.d(tag, "handleCallMediaButton: Media Rewind")
             playerNotificationService.jumpBackward()
           }
+          KeyEvent.KEYCODE_MEDIA_SKIP_FORWARD -> {
+            Log.d(tag, "handleCallMediaButton: Media Skip Forward")
+            playerNotificationService.skipToNext()
+          }
+          KeyEvent.KEYCODE_MEDIA_SKIP_BACKWARD -> {
+            Log.d(tag, "handleCallMediaButton: Media Skip Backward")
+            playerNotificationService.skipToPrevious()
+          }
         }
       }
 
@@ -231,6 +239,12 @@ class MediaSessionCallback(var playerNotificationService:PlayerNotificationServi
             playerNotificationService.skipToNext()
           }
           KeyEvent.KEYCODE_MEDIA_PREVIOUS -> {
+            playerNotificationService.skipToPrevious()
+          }
+          KeyEvent.KEYCODE_MEDIA_SKIP_FORWARD -> {
+            playerNotificationService.skipToNext()
+          }
+          KeyEvent.KEYCODE_MEDIA_SKIP_BACKWARD -> {
             playerNotificationService.skipToPrevious()
           }
           KeyEvent.KEYCODE_MEDIA_STOP -> {

--- a/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
@@ -576,7 +576,7 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
   }
 
   fun setMediaSessionConnectorPlaybackActions() {
-    var playbackActions =
+    val playbackActions =
             PlaybackStateCompat.ACTION_PLAY_PAUSE or
                     PlaybackStateCompat.ACTION_PLAY or
                     PlaybackStateCompat.ACTION_PAUSE or
@@ -584,11 +584,8 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
                     PlaybackStateCompat.ACTION_REWIND or
                     PlaybackStateCompat.ACTION_STOP or
                     PlaybackStateCompat.ACTION_SKIP_TO_NEXT or
-                    PlaybackStateCompat.ACTION_SKIP_TO_PREVIOUS
-
-    if (deviceSettings.allowSeekingOnMediaControls) {
-      playbackActions = playbackActions or PlaybackStateCompat.ACTION_SEEK_TO
-    }
+                    PlaybackStateCompat.ACTION_SKIP_TO_PREVIOUS or
+                    PlaybackStateCompat.ACTION_SEEK_TO
     mediaSessionConnector.setEnabledPlaybackActions(playbackActions)
   }
 

--- a/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
@@ -261,6 +261,7 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
     mediaSession =
             MediaSessionCompat(this, tag).apply {
               setSessionActivity(sessionActivityPendingIntent)
+              setFlags(MediaSessionCompat.FLAG_HANDLES_MEDIA_BUTTONS or MediaSessionCompat.FLAG_HANDLES_TRANSPORT_CONTROLS)
               isActive = true
             }
 


### PR DESCRIPTION
## Summary
- Add handling for `KEYCODE_MEDIA_SKIP_FORWARD/BACKWARD` to properly sync skip buttons from Bluetooth devices
- Always enable `ACTION_SEEK_TO` so external clients can expose the seek bar

## Testing
- `./gradlew assembleDebug` *(fails: Could not read script 'cordova.variables.gradle')*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688bc7913b7083208665ce118ef95c17