### PR TITLE
Switch local casts to remote stream

### DIFF
--- a/components/app/AudioPlayerContainer.vue
+++ b/components/app/AudioPlayerContainer.vue
@@ -184,13 +184,18 @@ export default {
       if (this.$refs.audioPlayer) {
         playbackRate = this.$refs.audioPlayer.currentPlaybackRate || 1
       }
-      AbsAudioPlayer.prepareLibraryItem({ libraryItemId, episodeId, playWhenReady: false, playbackRate })
+      const startTime = Math.floor(this.currentTime || 0)
+      const payload = { libraryItemId, episodeId, playWhenReady: false, playbackRate }
+      if (startTime) payload.startTime = startTime
+      AbsAudioPlayer.prepareLibraryItem(payload)
         .then((data) => {
           if (data.error) {
             const errorMsg = data.error || 'Failed to play'
             this.$toast.error(errorMsg)
           } else {
             console.log('Library item play response', JSON.stringify(data))
+            this.serverLibraryItemId = libraryItemId
+            this.serverEpisodeId = episodeId
             if (this.$store.state.isCasting) {
               AbsAudioPlayer.requestSession()
             }

--- a/pages/localMedia/item/_id.vue
+++ b/pages/localMedia/item/_id.vue
@@ -321,7 +321,7 @@ export default {
       if (this.playerIsStartingPlayback) return
       await this.$hapticsImpact()
       this.$store.commit('setPlayerIsStartingPlayback', this.localLibraryItemId)
-      this.$eventBus.$emit('play-item', { libraryItemId: this.localLibraryItemId })
+      this.$eventBus.$emit('play-item', { libraryItemId: this.localLibraryItemId, serverLibraryItemId: this.libraryItemId })
     },
     getCapImageSrc(contentUrl) {
       return Capacitor.convertFileSrc(contentUrl)


### PR DESCRIPTION
## Summary
- Switch casting of downloaded media to remote streaming and resume at current time
- Include server item IDs when playing local books to enable casting fallback

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_688ccaa2f8388320819582a33e111da5