### PR TITLE
Ensure queue advances in background

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/data/PlayQueueItem.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/data/PlayQueueItem.kt
@@ -1,0 +1,9 @@
+package com.audiobookshelf.app.data
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class PlayQueueItem(
+    var libraryItemId: String = "",
+    var episodeId: String? = null
+)

--- a/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsAudioPlayer.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsAudioPlayer.kt
@@ -283,6 +283,25 @@ class AbsAudioPlayer : Plugin() {
   }
 
   @PluginMethod
+  fun setPlayQueue(call: PluginCall) {
+    val queueIndex: Int = call.getInt("queueIndex") ?: 0
+    val queueJson = call.getArray("queue")
+
+    queueJson?.let {
+      try {
+        val queue: MutableList<PlayQueueItem> = jacksonMapper.readValue(it.toString())
+        playerNotificationService.setPlayQueue(queue, queueIndex)
+      } catch (e: Exception) {
+        Log.e(tag, "setPlayQueue: failed to parse queue", e)
+        call.reject("Invalid queue")
+        return
+      }
+    }
+
+    call.resolve()
+  }
+
+  @PluginMethod
   fun getCurrentTime(call: PluginCall) {
     Handler(Looper.getMainLooper()).post {
       val currentTime = playerNotificationService.getCurrentTimeSeconds()

--- a/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsAudioPlayer.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsAudioPlayer.kt
@@ -193,7 +193,7 @@ class AbsAudioPlayer : Plugin() {
     val playWhenReady = call.getBoolean("playWhenReady") == true
     val playbackRate = call.getFloat("playbackRate",1f) ?: 1f
     val startTimeOverride = call.getDouble("startTime")
-    val queueIndex = call.getInt("queueIndex", 0)
+    val queueIndex: Int = call.getInt("queueIndex") ?: 0
     val queueJson = call.getArray("queue")
 
     queueJson?.let {

--- a/components/app/AudioPlayerContainer.vue
+++ b/components/app/AudioPlayerContainer.vue
@@ -471,6 +471,13 @@ export default {
     ) {
       AbsAudioPlayer.requestSession()
     }
+
+    if (this.$store.state.playQueue.length) {
+      AbsAudioPlayer.setPlayQueue({
+        queue: this.$store.state.playQueue,
+        queueIndex: this.$store.state.queueIndex
+      })
+    }
   },
   beforeDestroy() {
     this.onLocalMediaProgressUpdateListener?.remove()

--- a/plugins/capacitor/AbsAudioPlayer.js
+++ b/plugins/capacitor/AbsAudioPlayer.js
@@ -77,7 +77,7 @@ class AbsAudioPlayerWeb extends WebPlugin {
   }
 
   // PluginMethod
-  async prepareLibraryItem({ libraryItemId, episodeId, playWhenReady, startTime, playbackRate }) {
+  async prepareLibraryItem({ libraryItemId, episodeId, playWhenReady, startTime, playbackRate, queue, queueIndex }) {
     console.log('[AbsAudioPlayer] Prepare library item', libraryItemId)
 
     if (!isNaN(playbackRate) && playbackRate) this.playbackRate = playbackRate

--- a/plugins/capacitor/AbsAudioPlayer.js
+++ b/plugins/capacitor/AbsAudioPlayer.js
@@ -104,6 +104,12 @@ class AbsAudioPlayerWeb extends WebPlugin {
   }
 
   // PluginMethod
+  setPlayQueue({ queue, queueIndex }) {
+    this.queue = queue
+    this.queueIndex = queueIndex
+  }
+
+  // PluginMethod
   async playPause() {
     if (!this.player) return
     if (this.player.ended) {


### PR DESCRIPTION
## Summary
- pass full play queue and index when starting playback
- manage queue state natively so next item plays in background
- sync queue index with UI via new onQueueIndexUpdate event

## Testing
- `./gradlew assembleDebug` *(fails: Could not read script 'android/capacitor-cordova-android-plugins/cordova.variables.gradle')*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688ccaca501083209f2a04930bae74d5