### PR TITLE
Switch local casts to remote stream

### DIFF
--- a/components/app/AudioPlayerContainer.vue
+++ b/components/app/AudioPlayerContainer.vue
@@ -177,9 +177,14 @@ export default {
       let episodeId = this.serverEpisodeId
       if (!libraryItemId) {
         const session = this.$store.state.currentPlaybackSession
-        if (session?.libraryItemId && !session.libraryItemId.startsWith('local')) {
-          libraryItemId = session.libraryItemId
-          episodeId = session.episodeId
+        if (session) {
+          if (session.libraryItemId && !session.libraryItemId.startsWith('local')) {
+            libraryItemId = session.libraryItemId
+            episodeId = session.episodeId
+          } else if (session.localLibraryItem?.libraryItemId) {
+            libraryItemId = session.localLibraryItem.libraryItemId
+            episodeId = session.localEpisode?.serverEpisodeId || null
+          }
         }
       }
       if (!libraryItemId) {
@@ -206,9 +211,7 @@ export default {
             console.log('Library item play response', JSON.stringify(data))
             this.serverLibraryItemId = libraryItemId
             this.serverEpisodeId = episodeId
-            if (this.$store.state.isCasting) {
-              AbsAudioPlayer.requestSession()
-            }
+            AbsAudioPlayer.requestSession()
           }
         })
         .catch((error) => {

--- a/pages/localMedia/item/_id.vue
+++ b/pages/localMedia/item/_id.vue
@@ -321,7 +321,7 @@ export default {
       if (this.playerIsStartingPlayback) return
       await this.$hapticsImpact()
       this.$store.commit('setPlayerIsStartingPlayback', this.localLibraryItemId)
-      this.$eventBus.$emit('play-item', { libraryItemId: this.localLibraryItemId })
+      this.$eventBus.$emit('play-item', { libraryItemId: this.localLibraryItemId, serverLibraryItemId: this.libraryItemId })
     },
     getCapImageSrc(contentUrl) {
       return Capacitor.convertFileSrc(contentUrl)


### PR DESCRIPTION
## Summary
- Handle cast attempts of downloaded items by finding matching server IDs and casting the remote stream instead
- Update cast availability from the player container so the cast button appears when devices are present

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ccaa2f8388320819582a33e111da5