### PR TITLE
Fix download checkmark truncation in list views

### DIFF
--- a/components/tables/collection/BookTableRow.vue
+++ b/components/tables/collection/BookTableRow.vue
@@ -6,7 +6,10 @@
       </div>
       <div class="book-table-content h-full px-2 flex items-center">
         <div class="max-w-full">
-          <p class="truncate block text-sm">{{ bookTitle }} <span v-if="localLibraryItem" class="material-symbols text-success text-base align-text-bottom">download_done</span></p>
+          <div class="flex items-center max-w-full">
+            <p class="truncate text-sm flex-grow">{{ bookTitle }}</p>
+            <span v-if="localLibraryItem" class="material-symbols text-success text-base flex-shrink-0 ml-1">download_done</span>
+          </div>
           <p class="truncate block text-fg-muted text-xs">{{ bookAuthor }}</p>
           <p v-if="media.duration" class="text-xxs text-fg-muted">{{ bookDuration }}</p>
         </div>

--- a/components/tables/playlist/ItemTableRow.vue
+++ b/components/tables/playlist/ItemTableRow.vue
@@ -7,7 +7,10 @@
         </div>
         <div class="item-table-content h-full px-2 flex items-center">
           <div class="max-w-full">
-            <p class="truncate block text-sm">{{ itemTitle }} <span v-if="localLibraryItem" class="material-symbols text-success text-base align-text-bottom">download_done</span></p>
+            <div class="flex items-center max-w-full">
+              <p class="truncate text-sm flex-grow">{{ itemTitle }}</p>
+              <span v-if="localLibraryItem" class="material-symbols text-success text-base flex-shrink-0 ml-1">download_done</span>
+            </div>
             <p v-if="authorName" class="truncate block text-fg-muted text-xs">{{ authorName }}</p>
             <p class="text-xxs text-fg-muted">{{ itemDuration }}</p>
           </div>


### PR DESCRIPTION
## Summary
- Ensure downloaded indicator has space in playlist and collection rows so it remains visible when titles are long

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688e5c6143108320b7404e290b5a2486