### PR TITLE
fix: prevent player overlay from blocking navigation

### DIFF
--- a/components/app/AudioPlayer.vue
+++ b/components/app/AudioPlayer.vue
@@ -30,7 +30,11 @@
       </div>
     </div>
 
-    <div class="cover-wrapper absolute z-30 pointer-events-auto" @click="clickContainer">
+    <div
+      class="cover-wrapper absolute z-30"
+      :class="{ 'pointer-events-none': !showFullscreen }"
+      @click="clickContainer"
+    >
       <div class="w-full h-full flex justify-center">
         <covers-book-cover v-if="libraryItem || localLibraryItemCoverSrc" ref="cover" :library-item="libraryItem" :download-cover="localLibraryItemCoverSrc" :width="bookCoverWidth" :book-cover-aspect-ratio="bookCoverAspectRatio" raw @imageLoaded="coverImageLoaded" />
       </div>
@@ -40,7 +44,11 @@
       </div>
     </div>
 
-    <div class="title-author-texts absolute z-30 left-0 right-0 overflow-hidden" @click="clickTitleAndAuthor">
+    <div
+      class="title-author-texts absolute z-30 left-0 right-0 overflow-hidden"
+      :class="{ 'pointer-events-none': !showFullscreen }"
+      @click="clickTitleAndAuthor"
+    >
       <div ref="titlewrapper" class="overflow-hidden relative">
         <p class="title-text whitespace-nowrap"></p>
       </div>


### PR DESCRIPTION
## Summary
- ensure minimized player overlay doesn't intercept bookshelf tab taps by disabling pointer events on cover and title when collapsed

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688e689c6f148320ba35d46c2e9cc412