### PR TITLE
Improve offline podcast experience

### DIFF
--- a/components/bookshelf/LazyBookshelf.vue
+++ b/components/bookshelf/LazyBookshelf.vue
@@ -184,9 +184,16 @@ export default {
       const fullQueryString = `?${sfQueryString}limit=${this.booksPerFetch}&page=${page}&minified=1&include=rssfeed,numEpisodesIncomplete`
 
       let payload
-      if (this.entityName === 'playlists' && !this.networkConnected) {
-        const cached = await this.$localStore.getCachedPlaylists(this.currentLibraryId)
-        payload = { results: cached.slice(startIndex, startIndex + this.booksPerFetch), total: cached.length }
+      if (!this.networkConnected) {
+        if (this.entityName === 'playlists') {
+          const cached = await this.$localStore.getCachedPlaylists(this.currentLibraryId)
+          payload = { results: cached.slice(startIndex, startIndex + this.booksPerFetch), total: cached.length }
+        } else if (this.entityName === 'books' || this.entityName === 'series-books') {
+          const results = this.localLibraryItems.slice(startIndex, startIndex + this.booksPerFetch)
+          payload = { results, total: this.localLibraryItems.length }
+        } else {
+          payload = { results: [], total: 0 }
+        }
       } else {
         payload = await this.$nativeHttp.get(`/api/libraries/${this.currentLibraryId}/${entityPath}${fullQueryString}`).catch((error) => {
           console.error('failed to fetch books', error)

--- a/pages/bookshelf/latest.vue
+++ b/pages/bookshelf/latest.vue
@@ -72,9 +72,33 @@ export default {
       this.loadedLibraryId = this.currentLibraryId
       this.processing = true
       if (!this.networkConnected) {
+        if (!this.localLibraryItems.length) {
+          await this.loadLocalPodcastLibraryItems()
+        }
         const cached = await this.$localStore.getCachedLatestEpisodes(this.currentLibraryId)
-        this.recentEpisodes = cached
-        this.totalEpisodes = cached.length
+        if (cached.length) {
+          this.recentEpisodes = cached
+        } else {
+          const parseDate = (ep) => {
+            let val = ep.publishedAt ?? ep.pubDate
+            if (!val) return 0
+            if (typeof val === 'string') {
+              const num = Number(val)
+              if (!isNaN(num)) val = num
+            }
+            if (typeof val === 'number') {
+              if (val < 1e12) val *= 1000
+              return val
+            }
+            const parsed = Date.parse(val)
+            return isNaN(parsed) ? 0 : parsed
+          }
+          this.recentEpisodes = this.localEpisodes
+            .slice()
+            .sort((a, b) => parseDate(b) - parseDate(a))
+            .slice(0, 200)
+        }
+        this.totalEpisodes = this.recentEpisodes.length
         this.processing = false
         return
       }
@@ -114,9 +138,9 @@ export default {
       }
     }
   },
-  mounted() {
+  async mounted() {
+    await this.loadLocalPodcastLibraryItems()
     this.loadRecentEpisodes()
-    this.loadLocalPodcastLibraryItems()
     this.$eventBus.$on('library-changed', this.libraryChanged)
     this.$eventBus.$on('new-local-library-item', this.newLocalLibraryItem)
   },

--- a/pages/bookshelf/playlists.vue
+++ b/pages/bookshelf/playlists.vue
@@ -56,9 +56,9 @@ export default {
       for (const li of localLibraries) {
         let episodes = li.media?.episodes || []
 
-        const cachedMeta = await this.$localStore.getEpisodeMetadata(
+        const cachedMeta = (await this.$localStore.getEpisodeMetadata(
           li.libraryItemId
-        )
+        )) || []
         const metaMap = {}
         cachedMeta.forEach((m) => {
           if (m && m.id) metaMap[m.id] = m

--- a/pages/playlist/_id.vue
+++ b/pages/playlist/_id.vue
@@ -134,9 +134,9 @@ export default {
         for (const li of localLibraries) {
           let episodes = li.media?.episodes || []
 
-          const cachedMeta = await this.$localStore.getEpisodeMetadata(
+        const cachedMeta = (await this.$localStore.getEpisodeMetadata(
             li.libraryItemId
-          )
+          )) || []
           const metaMap = {}
           cachedMeta.forEach((m) => {
             if (m && m.id) metaMap[m.id] = m


### PR DESCRIPTION
## Summary
- Serve locally downloaded episodes on Latest tab when offline
- Avoid crashes in unfinished playlist by handling missing episode metadata
- Use local library items for bookshelf when disconnected

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*


------
https://chatgpt.com/codex/tasks/task_e_688e6971ecc4832095c26980b21493f4