### PR TITLE
feat: improve podcast offline support

### DIFF
--- a/components/bookshelf/LazyBookshelf.vue
+++ b/components/bookshelf/LazyBookshelf.vue
@@ -184,9 +184,14 @@ export default {
       const fullQueryString = `?${sfQueryString}limit=${this.booksPerFetch}&page=${page}&minified=1&include=rssfeed,numEpisodesIncomplete`
 
       let payload
-      if (this.entityName === 'playlists' && !this.networkConnected) {
-        const cached = await this.$localStore.getCachedPlaylists(this.currentLibraryId)
-        payload = { results: cached.slice(startIndex, startIndex + this.booksPerFetch), total: cached.length }
+      if (!this.networkConnected) {
+        if (this.entityName === 'playlists') {
+          const cached = await this.$localStore.getCachedPlaylists(this.currentLibraryId)
+          payload = { results: cached.slice(startIndex, startIndex + this.booksPerFetch), total: cached.length }
+        } else if (this.entityName === 'books') {
+          const results = this.localLibraryItems.slice(startIndex, startIndex + this.booksPerFetch)
+          payload = { results, total: this.localLibraryItems.length }
+        }
       } else {
         payload = await this.$nativeHttp.get(`/api/libraries/${this.currentLibraryId}/${entityPath}${fullQueryString}`).catch((error) => {
           console.error('failed to fetch books', error)
@@ -230,7 +235,7 @@ export default {
       }
     },
     async loadPage(page) {
-      if (!this.currentLibraryId) {
+      if (this.networkConnected && !this.currentLibraryId) {
         console.error('[LazyBookshelf] loadPage current library id not set')
         return
       }

--- a/pages/bookshelf/playlists.vue
+++ b/pages/bookshelf/playlists.vue
@@ -141,6 +141,7 @@ export default {
       this.checkAutoDownload()
     },
     async checkAutoDownload() {
+      if (!this.networkConnected) return
       if (!this.$store.state.deviceData?.deviceSettings?.autoCacheUnplayedEpisodes) return
       const localItems = await this.$db.getLocalLibraryItems('podcast')
       for (const qi of this.autoPlaylist.items) {

--- a/pages/playlist/_id.vue
+++ b/pages/playlist/_id.vue
@@ -323,6 +323,7 @@ export default {
       }
     },
     async checkAutoDownload() {
+      if (!this.networkConnected) return
       if (!this.$store.state.deviceData?.deviceSettings?.autoCacheUnplayedEpisodes) return
       const localItems = await this.$db.getLocalLibraryItems('podcast')
       for (const qi of this.playlist.items) {


### PR DESCRIPTION
## Summary
- show downloaded episodes in Latest when offline
- load local library items for offline library view
- avoid auto-downloads when network is disconnected

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_688e6971ecc4832095c26980b21493f4