### PR TITLE
fix: restore auto download timer for unplayed episodes

### DIFF
--- a/store/index.js
+++ b/store/index.js
@@ -230,6 +230,13 @@ export const actions = {
 export const mutations = {
   setDeviceData(state, deviceData) {
     state.deviceData = deviceData
+
+    // Ensure auto download timer reflects the "auto cache unplayed episodes" setting
+    if (deviceData?.deviceSettings?.autoCacheUnplayedEpisodes) {
+      this.dispatch('startAutoDownloadTimer')
+    } else {
+      this.dispatch('stopAutoDownloadTimer')
+    }
   },
   setLastBookshelfScrollData(state, { scrollTop, path, name }) {
     state.lastBookshelfScrollData[name] = { scrollTop, path }


### PR DESCRIPTION
## Summary
- restart or stop auto-download timer when device settings change

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_688e722dda2c83209eb19f462f718e34