### PR TITLE
fix: use server episode ids for auto podcast downloads

### DIFF
--- a/pages/bookshelf/playlists.vue
+++ b/pages/bookshelf/playlists.vue
@@ -145,11 +145,11 @@ export default {
       if (!this.$store.state.deviceData?.deviceSettings?.autoCacheUnplayedEpisodes) return
       const localItems = await this.$db.getLocalLibraryItems('podcast')
       for (const qi of this.autoPlaylist.items) {
-        const liId = qi.libraryItem.id
-        const epId = qi.episode.id
+        const liId = qi.libraryItemId || qi.libraryItem?.libraryItemId || qi.libraryItem?.id
+        const epId = qi.episodeId || qi.episode?.serverEpisodeId || qi.episode?.id
         const localLi = localItems.find((lli) => lli.libraryItemId === liId)
         const localEp = localLi?.media?.episodes?.find((ep) => ep.serverEpisodeId === epId)
-        if (!localEp) {
+        if (!localEp && liId && epId) {
           AbsDownloader.downloadLibraryItem({ libraryItemId: liId, episodeId: epId })
         }
       }

--- a/pages/playlist/_id.vue
+++ b/pages/playlist/_id.vue
@@ -327,11 +327,11 @@ export default {
       if (!this.$store.state.deviceData?.deviceSettings?.autoCacheUnplayedEpisodes) return
       const localItems = await this.$db.getLocalLibraryItems('podcast')
       for (const qi of this.playlist.items) {
-        const liId = qi.libraryItem.id
-        const epId = qi.episode.id
+        const liId = qi.libraryItemId || qi.libraryItem?.libraryItemId || qi.libraryItem?.id
+        const epId = qi.episodeId || qi.episode?.serverEpisodeId || qi.episode?.id
         const localLi = localItems.find((lli) => lli.libraryItemId === liId)
         const localEp = localLi?.media?.episodes?.find((ep) => ep.serverEpisodeId === epId)
-        if (!localEp) {
+        if (!localEp && liId && epId) {
           AbsDownloader.downloadLibraryItem({ libraryItemId: liId, episodeId: epId })
         }
       }


### PR DESCRIPTION
## Summary
- ensure auto download uses server library and episode ids for unfinished podcasts

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*


------
https://chatgpt.com/codex/tasks/task_e_688e722dda2c83209eb19f462f718e34