### PR TITLE
fix: resume podcast auto-download after network reconnect

### DIFF
--- a/pages/bookshelf/playlists.vue
+++ b/pages/bookshelf/playlists.vue
@@ -31,10 +31,14 @@ export default {
   },
   watch: {
     networkConnected(newVal) {
-      if (newVal && !this.autoPlaylist.items.length) {
-        setTimeout(() => {
-          this.fetchAutoPlaylist()
-        }, 1000)
+      if (newVal) {
+        if (!this.autoPlaylist.items.length) {
+          setTimeout(() => {
+            this.fetchAutoPlaylist()
+          }, 1000)
+        } else {
+          this.checkAutoDownload()
+        }
       }
     }
   },

--- a/pages/playlist/_id.vue
+++ b/pages/playlist/_id.vue
@@ -62,10 +62,14 @@ export default {
   },
   watch: {
     networkConnected(newVal) {
-      if (newVal && !this.playlist.items.length) {
-        setTimeout(() => {
-          this.fetchPlaylist()
-        }, 1000)
+      if (newVal) {
+        if (!this.playlist.items.length) {
+          setTimeout(() => {
+            this.fetchPlaylist()
+          }, 1000)
+        } else {
+          this.checkAutoDownload()
+        }
       }
     }
   },


### PR DESCRIPTION
## Summary
- start auto downloads when network connection becomes available on playlists pages

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688e722dda2c83209eb19f462f718e34