### PR TITLE
Add progress indicators and toggle for unfinished podcasts

### DIFF
--- a/components/tables/playlist/ItemTableRow.vue
+++ b/components/tables/playlist/ItemTableRow.vue
@@ -48,11 +48,14 @@ export default {
   },
   computed: {
     itemUrl() {
-      if (this.episodeId) return `/item/${this.libraryItem.id}/${this.episodeId}`
-      return `/item/${this.libraryItem.id}`
+      if (this.episodeId) return `/item/${this.libraryItemId}/${this.episodeId}`
+      return `/item/${this.libraryItemId}`
     },
     libraryItem() {
       return this.item.libraryItem || {}
+    },
+    libraryItemId() {
+      return this.item.libraryItemId || this.libraryItem.id
     },
     localLibraryItem() {
       return this.item.localLibraryItem
@@ -117,8 +120,13 @@ export default {
       return !this.isMissing && !this.isInvalid && (this.tracks.length || this.episode)
     },
     isOpenInPlayer() {
-      if (this.localLibraryItem && this.localEpisode && this.$store.getters['getIsMediaStreaming'](this.localLibraryItem.id, this.localEpisode.id)) return true
-      return this.$store.getters['getIsMediaStreaming'](this.libraryItem.id, this.episodeId)
+      if (
+        this.localLibraryItem &&
+        this.localEpisode &&
+        this.$store.getters['getIsMediaStreaming'](this.localLibraryItem.id, this.localEpisode.id)
+      )
+        return true
+      return this.$store.getters['getIsMediaStreaming'](this.libraryItemId, this.episodeId)
     },
     streamIsPlaying() {
       return this.$store.state.playerIsPlaying && this.isOpenInPlayer
@@ -131,11 +139,20 @@ export default {
       const mediaId = this.$store.state.playerStartingPlaybackMediaId
       if (!mediaId) return false
 
-      let thisMediaId = this.episodeId || this.libraryItem.id
+      let thisMediaId = this.episodeId || this.libraryItemId
       return mediaId === thisMediaId
     },
     userItemProgress() {
-      return this.$store.getters['user/getUserMediaProgress'](this.libraryItem.id, this.episodeId)
+      return (
+        this.$store.getters['globals/getLocalMediaProgressByServerItemId'](
+          this.libraryItemId,
+          this.episodeId
+        ) ||
+        this.$store.getters['user/getUserMediaProgress'](
+          this.libraryItemId,
+          this.episodeId
+        )
+      )
     },
     userIsFinished() {
       return !!this.userItemProgress?.isFinished
@@ -162,7 +179,7 @@ export default {
       if (this.playerIsStartingPlayback) return
 
       await this.$hapticsImpact()
-      let mediaId = this.episodeId || this.libraryItem.id
+      let mediaId = this.episodeId || this.libraryItemId
       if (this.streamIsPlaying) {
         this.$eventBus.$emit('pause-item')
       } else if (this.localLibraryItem) {
@@ -170,13 +187,13 @@ export default {
         this.$eventBus.$emit('play-item', {
           libraryItemId: this.localLibraryItem.id,
           episodeId: this.localEpisode?.id,
-          serverLibraryItemId: this.libraryItem.id,
+          serverLibraryItemId: this.libraryItemId,
           serverEpisodeId: this.episodeId
         })
       } else {
         this.$store.commit('setPlayerIsStartingPlayback', mediaId)
         this.$eventBus.$emit('play-item', {
-          libraryItemId: this.libraryItem.id,
+          libraryItemId: this.libraryItemId,
           episodeId: this.episodeId
         })
       }

--- a/pages/bookshelf/playlists.vue
+++ b/pages/bookshelf/playlists.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="w-full h-full overflow-y-auto">
-    <div class="px-4 pt-4">
+    <div class="px-4 pt-4" v-if="showAutoPlaylist">
       <div class="mb-4 border border-fg/20 rounded p-4 flex items-center">
         <nuxt-link to="/playlist/unfinished" class="flex items-center flex-grow">
           <covers-playlist-cover :items="autoPlaylist.items" :width="64" :height="64" />
@@ -27,10 +27,11 @@ export default {
     }
   },
   mounted() {
-    this.fetchAutoPlaylist()
+    if (this.showAutoPlaylist) this.fetchAutoPlaylist()
   },
   watch: {
     networkConnected(newVal) {
+      if (!this.showAutoPlaylist) return
       if (newVal) {
         if (!this.autoPlaylist.items.length) {
           setTimeout(() => {
@@ -45,12 +46,18 @@ export default {
   computed: {
     networkConnected() {
       return this.$store.state.networkConnected
+    },
+    showAutoPlaylist() {
+      return this.$store.state.deviceData?.deviceSettings?.autoCacheUnplayedEpisodes
     }
   },
   methods: {
     async fetchAutoPlaylist() {
       const progressMap = {}
       ;(this.$store.state.user.user?.mediaProgress || []).forEach((mp) => {
+        if (mp.episodeId) progressMap[mp.episodeId] = mp
+      })
+      ;(this.$store.state.globals.localMediaProgress || []).forEach((mp) => {
         if (mp.episodeId) progressMap[mp.episodeId] = mp
       })
 

--- a/pages/playlist/_id.vue
+++ b/pages/playlist/_id.vue
@@ -131,6 +131,9 @@ export default {
         ;(this.$store.state.user.user?.mediaProgress || []).forEach((mp) => {
           if (mp.episodeId) progressMap[mp.episodeId] = mp
         })
+        ;(this.$store.state.globals.localMediaProgress || []).forEach((mp) => {
+          if (mp.episodeId) progressMap[mp.episodeId] = mp
+        })
 
         const items = []
         const seen = new Set()


### PR DESCRIPTION
## Summary
- show playlist items progress using local media data and stable IDs
- gate unfinished podcast playlist behind auto-cache setting
- factor local progress into unfinished playlist generation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_6893687ae9a08320ad3cb4ad81ca6f4f