### PR TITLE
feat: add toggle for unfinished podcast playlist

### DIFF
--- a/components/tables/playlist/ItemTableRow.vue
+++ b/components/tables/playlist/ItemTableRow.vue
@@ -61,7 +61,8 @@ export default {
       return this.item.episode
     },
     episodeId() {
-      return this.episode?.id || null
+      // Prefer the server episode id so progress can be looked up correctly
+      return this.item.episodeId || this.episode?.serverEpisodeId || this.episode?.id || null
     },
     localEpisode() {
       return this.item.localEpisode

--- a/pages/bookshelf/playlists.vue
+++ b/pages/bookshelf/playlists.vue
@@ -1,7 +1,10 @@
 <template>
   <div class="w-full h-full overflow-y-auto">
     <div class="px-4 pt-4">
-      <div class="mb-4 border border-fg/20 rounded p-4 flex items-center">
+      <div
+        v-if="autoCacheUnplayedEpisodes"
+        class="mb-4 border border-fg/20 rounded p-4 flex items-center"
+      >
         <nuxt-link to="/playlist/unfinished" class="flex items-center flex-grow">
           <covers-playlist-cover :items="autoPlaylist.items" :width="64" :height="64" />
           <p class="text-lg ml-4">{{ autoPlaylist.name }}</p>
@@ -16,8 +19,11 @@
 import { AbsDownloader } from '@/plugins/capacitor'
 export default {
   async asyncData({ store, app }) {
-    const cached = await app.$localStore.getCachedPlaylist('unfinished')
     const name = app.$strings.LabelAutoUnfinishedPodcasts
+    const enabled = store.state.deviceData?.deviceSettings?.autoCacheUnplayedEpisodes
+    if (!enabled)
+      return { autoPlaylist: { id: 'unfinished', name, items: [] } }
+    const cached = await app.$localStore.getCachedPlaylist('unfinished')
     if (cached) return { autoPlaylist: cached }
     return { autoPlaylist: { id: 'unfinished', name, items: [] } }
   },
@@ -27,11 +33,11 @@ export default {
     }
   },
   mounted() {
-    this.fetchAutoPlaylist()
+    if (this.autoCacheUnplayedEpisodes) this.fetchAutoPlaylist()
   },
   watch: {
     networkConnected(newVal) {
-      if (newVal) {
+      if (newVal && this.autoCacheUnplayedEpisodes) {
         if (!this.autoPlaylist.items.length) {
           setTimeout(() => {
             this.fetchAutoPlaylist()
@@ -40,11 +46,19 @@ export default {
           this.checkAutoDownload()
         }
       }
+    },
+    autoCacheUnplayedEpisodes(newVal) {
+      if (newVal && !this.autoPlaylist.items.length) {
+        this.fetchAutoPlaylist()
+      }
     }
   },
   computed: {
     networkConnected() {
       return this.$store.state.networkConnected
+    },
+    autoCacheUnplayedEpisodes() {
+      return this.$store.state.deviceData?.deviceSettings?.autoCacheUnplayedEpisodes
     }
   },
   methods: {
@@ -108,8 +122,9 @@ export default {
           const key = `${li.libraryItemId}_${serverId}`
           if (seen.has(key)) continue
           seen.add(key)
+          const serverLibraryItem = { ...li, id: li.libraryItemId }
           items.push({
-            libraryItem: li,
+            libraryItem: serverLibraryItem,
             episode: ep,
             libraryItemId: li.libraryItemId,
             episodeId: serverId,

--- a/pages/playlist/_id.vue
+++ b/pages/playlist/_id.vue
@@ -63,13 +63,22 @@ export default {
   watch: {
     networkConnected(newVal) {
       if (newVal) {
-        if (!this.playlist.items.length) {
+        if (!this.playlist.items.length && this.autoCacheUnplayedEpisodes) {
           setTimeout(() => {
             this.fetchPlaylist()
           }, 1000)
         } else {
           this.checkAutoDownload()
         }
+      }
+    },
+    autoCacheUnplayedEpisodes(newVal) {
+      if (
+        newVal &&
+        this.$route.params.id === 'unfinished' &&
+        !this.playlist.items.length
+      ) {
+        this.fetchPlaylist()
       }
     }
   },
@@ -120,6 +129,9 @@ export default {
       if (!this.mediaIdStartingPlayback) return false
       const mediaId = this.$store.state.playerStartingPlaybackMediaId
       return mediaId === this.mediaIdStartingPlayback
+    },
+    autoCacheUnplayedEpisodes() {
+      return this.$store.state.deviceData?.deviceSettings?.autoCacheUnplayedEpisodes
     }
   },
   methods: {
@@ -127,97 +139,109 @@ export default {
       const id = this.$route.params.id
       let playlist
       if (id === 'unfinished') {
-        const progressMap = {}
-        ;(this.$store.state.user.user?.mediaProgress || []).forEach((mp) => {
-          if (mp.episodeId) progressMap[mp.episodeId] = mp
-        })
-
-        const items = []
-        const seen = new Set()
-        const localLibraries = await this.$db.getLocalLibraryItems('podcast')
-        for (const li of localLibraries) {
-          let episodes = li.media?.episodes || []
-
-        const cachedMeta = (await this.$localStore.getEpisodeMetadata(
-            li.libraryItemId
-          )) || []
-          const metaMap = {}
-          cachedMeta.forEach((m) => {
-            if (m && m.id) metaMap[m.id] = m
+        if (!this.autoCacheUnplayedEpisodes) {
+          playlist = {
+            id: 'unfinished',
+            name: this.$strings.LabelAutoUnfinishedPodcasts,
+            description: '',
+            items: []
+          }
+        } else {
+          const progressMap = {}
+          ;(this.$store.state.user.user?.mediaProgress || []).forEach((mp) => {
+            if (mp.episodeId) progressMap[mp.episodeId] = mp
           })
-          episodes = episodes.map((ep) => {
-            const id = ep.serverEpisodeId || ep.id
-            if (id && (!ep.publishedAt && !ep.pubDate) && metaMap[id]) {
-              return {
-                ...ep,
-                publishedAt: metaMap[id].publishedAt,
-                pubDate: metaMap[id].pubDate
+
+          const items = []
+          const seen = new Set()
+          const localLibraries = await this.$db.getLocalLibraryItems('podcast')
+          for (const li of localLibraries) {
+            let episodes = li.media?.episodes || []
+
+            const cachedMeta =
+              (await this.$localStore.getEpisodeMetadata(li.libraryItemId)) || []
+            const metaMap = {}
+            cachedMeta.forEach((m) => {
+              if (m && m.id) metaMap[m.id] = m
+            })
+            episodes = episodes.map((ep) => {
+              const id = ep.serverEpisodeId || ep.id
+              if (id && (!ep.publishedAt && !ep.pubDate) && metaMap[id]) {
+                return {
+                  ...ep,
+                  publishedAt: metaMap[id].publishedAt,
+                  pubDate: metaMap[id].pubDate
+                }
+              }
+              return ep
+            })
+
+            let missingDates = episodes.some((e) => !e.publishedAt && !e.pubDate)
+            if (this.$store.state.networkConnected && missingDates) {
+              const serverItem = await this.$nativeHttp
+                .get(`/api/items/${li.libraryItemId}?expanded=1`)
+                .catch(() => null)
+              if (serverItem?.media?.episodes?.length) {
+                episodes = serverItem.media.episodes.map((se) => {
+                  const localEp = li.media?.episodes?.find(
+                    (lep) => lep.serverEpisodeId === se.id
+                  )
+                  return localEp ? { ...se, localEpisode: localEp } : se
+                })
+                const meta = serverItem.media.episodes.map((se) => ({
+                  id: se.id,
+                  pubDate: se.pubDate,
+                  publishedAt: se.publishedAt
+                }))
+                await this.$localStore.setEpisodeMetadata(
+                  li.libraryItemId,
+                  meta
+                )
               }
             }
-            return ep
-          })
-
-          let missingDates = episodes.some((e) => !e.publishedAt && !e.pubDate)
-          if (this.$store.state.networkConnected && missingDates) {
-            const serverItem = await this.$nativeHttp
-              .get(`/api/items/${li.libraryItemId}?expanded=1`)
-              .catch(() => null)
-            if (serverItem?.media?.episodes?.length) {
-              episodes = serverItem.media.episodes.map((se) => {
-                const localEp = li.media?.episodes?.find(
-                  (lep) => lep.serverEpisodeId === se.id
-                )
-                return localEp ? { ...se, localEpisode: localEp } : se
+            for (const ep of episodes) {
+              const serverId = ep.serverEpisodeId || ep.id
+              if (!serverId) continue
+              const prog = progressMap[serverId]
+              if (prog && prog.isFinished) continue
+              const key = `${li.libraryItemId}_${serverId}`
+              if (seen.has(key)) continue
+              seen.add(key)
+              const serverLibraryItem = { ...li, id: li.libraryItemId }
+              items.push({
+                libraryItem: serverLibraryItem,
+                episode: ep,
+                libraryItemId: li.libraryItemId,
+                episodeId: serverId,
+                localLibraryItem: li,
+                localEpisode: ep.localEpisode || ep
               })
-              const meta = serverItem.media.episodes.map((se) => ({
-                id: se.id,
-                pubDate: se.pubDate,
-                publishedAt: se.publishedAt
-              }))
-              await this.$localStore.setEpisodeMetadata(li.libraryItemId, meta)
             }
           }
-          for (const ep of episodes) {
-            const serverId = ep.serverEpisodeId || ep.id
-            if (!serverId) continue
-            const prog = progressMap[serverId]
-            if (prog && prog.isFinished) continue
-            const key = `${li.libraryItemId}_${serverId}`
-            if (seen.has(key)) continue
-            seen.add(key)
-            items.push({
-              libraryItem: li,
-              episode: ep,
-              libraryItemId: li.libraryItemId,
-              episodeId: serverId,
-              localLibraryItem: li,
-              localEpisode: ep.localEpisode || ep
-            })
-          }
-        }
 
-        const parseDate = (ep) => {
-          if (!ep) return 0
-          let val = ep.publishedAt ?? ep.pubDate
-          if (!val) return 0
-          if (typeof val === 'string') {
-            const num = Number(val)
-            if (!isNaN(num)) val = num
+          const parseDate = (ep) => {
+            if (!ep) return 0
+            let val = ep.publishedAt ?? ep.pubDate
+            if (!val) return 0
+            if (typeof val === 'string') {
+              const num = Number(val)
+              if (!isNaN(num)) val = num
+            }
+            if (typeof val === 'number') {
+              if (val < 1e12) val *= 1000
+              return val
+            }
+            const parsed = Date.parse(val)
+            return isNaN(parsed) ? 0 : parsed
           }
-          if (typeof val === 'number') {
-            if (val < 1e12) val *= 1000
-            return val
-          }
-          const parsed = Date.parse(val)
-          return isNaN(parsed) ? 0 : parsed
-        }
-        items.sort((a, b) => parseDate(a.episode) - parseDate(b.episode))
+          items.sort((a, b) => parseDate(a.episode) - parseDate(b.episode))
 
-        playlist = {
-          id: 'unfinished',
-          name: this.$strings.LabelAutoUnfinishedPodcasts,
-          description: '',
-          items
+          playlist = {
+            id: 'unfinished',
+            name: this.$strings.LabelAutoUnfinishedPodcasts,
+            description: '',
+            items
+          }
         }
       } else {
         if (!this.$store.state.networkConnected) {


### PR DESCRIPTION
## Summary
- hide Unfinished Podcast playlist unless auto-cache setting is enabled
- ensure unfinished playlist episodes show progress bar by using server IDs
- fix playlist rows to prioritize server episode IDs when calculating progress

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6893687ae9a08320ad3cb4ad81ca6f4f