### PR TITLE
Handle offline unfinished playlist

### DIFF
--- a/pages/playlist/_id.vue
+++ b/pages/playlist/_id.vue
@@ -45,7 +45,8 @@ export default {
   async asyncData({ store, params, app, redirect, route }) {
     const user = store.state.user.user
     const serverConfig = store.state.user.serverConnectionConfig
-    if (!user && !serverConfig) {
+    const networkConnected = store.state.networkConnected
+    if (!user && !serverConfig && networkConnected) {
       return redirect(`/connect?redirect=${route.path}`)
     }
 
@@ -151,6 +152,9 @@ export default {
         } else {
           const progressMap = {}
           ;(this.$store.state.user.user?.mediaProgress || []).forEach((mp) => {
+            if (mp.episodeId) progressMap[mp.episodeId] = mp
+          })
+          ;(this.$store.state.globals.localMediaProgress || []).forEach((mp) => {
             if (mp.episodeId) progressMap[mp.episodeId] = mp
           })
 


### PR DESCRIPTION
## Summary
- Prevent login redirect when opening the unfinished playlist while offline
- Include local media progress when building the offline unfinished playlist

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68980b44d2ac8320978079ad9bf6c885