### PR TITLE
fix offline access for unfinished playlist

### DIFF
--- a/middleware/authenticated.js
+++ b/middleware/authenticated.js
@@ -3,6 +3,7 @@ export default function ({ store, redirect, route }) {
   const serverConfig = store.state.user.serverConnectionConfig
 
   if (!user && !serverConfig) {
+    if (route.name === 'playlist-id' && route.params.id === 'unfinished') return
     return redirect(`/connect?redirect=${route.path}`)
   }
 }

--- a/pages/playlist/_id.vue
+++ b/pages/playlist/_id.vue
@@ -45,7 +45,7 @@ export default {
   async asyncData({ store, params, app, redirect, route }) {
     const user = store.state.user.user
     const serverConfig = store.state.user.serverConnectionConfig
-    if (!user && !serverConfig) {
+    if (!user && !serverConfig && params.id !== 'unfinished') {
       return redirect(`/connect?redirect=${route.path}`)
     }
 


### PR DESCRIPTION
## Summary
- allow auto 'unfinished' playlist to load when offline without redirecting to login
- skip auth middleware redirect for offline unfinished playlist route

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68980b44d2ac8320978079ad9bf6c885