### PR TITLE
Persist fuzzy-finished podcasts before removing from unfinished auto-playlist

### DIFF
--- a/components/modals/ItemMoreMenuModal.vue
+++ b/components/modals/ItemMoreMenuModal.vue
@@ -614,7 +614,7 @@ export default {
             userIsFinished: this.userIsFinished
           })}`
         })
-        if (this.userIsFinished) {
+        if (this.userItemProgress?.isFinished) {
           this.$toast.success('Item removed from playlist')
           this.$emit('removed-from-auto-playlist')
           return
@@ -657,7 +657,7 @@ export default {
       let markFinishedSucceeded = false
 
       if (this.episode) {
-        if (this.userIsFinished) return
+        if (this.userItemProgress?.isFinished) return
         if (this.isLocal || this.localEpisode) {
           const payload = await this.$db.updateLocalMediaProgressFinished({
             localLibraryItemId: this.localLibraryItemId,
@@ -688,7 +688,7 @@ export default {
           }
         }
       } else {
-        if (this.userIsFinished) return
+        if (this.userItemProgress?.isFinished) return
         if (this.isLocal) {
           const payload = await this.$db.updateLocalMediaProgressFinished({
             localLibraryItemId: this.localLibraryItemId,
@@ -719,7 +719,7 @@ export default {
         }
       }
 
-      if (markFinishedSucceeded && this.playlist?.id === 'unfinished' && !this.userIsFinished) {
+      if (markFinishedSucceeded && this.playlist?.id === 'unfinished' && !this.userItemProgress?.isFinished) {
         this.$emit('removed-from-auto-playlist', { refresh: true })
       }
     },


### PR DESCRIPTION
### Motivation
- The UI treats items with progress >= ~97% as finished for display, but that fuzzy threshold did not always persist `isFinished` in progress metadata, causing items to appear finished while underlying metadata remained unfinished.
- The auto-playlist removal flow previously short-circuited on the UI-only finished check and removed items without ensuring persisted progress was updated.

### Description
- Change the auto-playlist removal and force-finish logic in `components/modals/ItemMoreMenuModal.vue` to gate early exits on the persisted state (`userItemProgress?.isFinished`) instead of the fuzzy UI computed `userIsFinished` value.
- Update guards inside `removeFromPlaylistClick()` and `forceMarkFinished()` so episodes/items that only look finished still call the progress API/local DB to persist `isFinished: true` before being removed from the `unfinished` auto-playlist.
- Emit removal from the auto-playlist only after successful persistence when needed, and avoid changing any visual/UI components (logic-only fix).
- Files modified: `components/modals/ItemMoreMenuModal.vue`.

### Testing
- Ran `scripts/install-android-sdk.sh` which installed the SDK at `/opt/android-sdk` (succeeded).
- Ran `npm install` then `npm run lint` which completed with no lint errors after dependencies were installed (succeeded).
- Ran Android static analysis as required via `cd android && ./gradlew --no-daemon staticAnalysis`; initial attempt revealed a Java toolchain mismatch, then after installing OpenJDK 21 and running with `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 ANDROID_HOME=/opt/android-sdk ./gradlew --no-daemon staticAnalysis` the static analysis completed successfully (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999cb9bf068832096c2c663d91aa4da)