### PR TITLE
ci: combine staticAnalysis and assembleDebug to maximize Gradle reuse

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -64,18 +64,16 @@ jobs:
           build-scan-terms-of-use-url: "https://gradle.com/terms-of-service"
           build-scan-terms-of-use-agree: "yes"
 
-      - name: Run static analysis
-        working-directory: android
-        run: ./gradlew --no-daemon staticAnalysis
-
       - name: Setup debug keystore
         run: |
           mkdir -p "$HOME/.android"
           cp android/debug.keystore "$HOME/.android/debug.keystore"
 
-      - name: Build Android app (Debug)
+      # Run both tasks in one Gradle invocation so task outputs/configuration state can be reused
+      # within the same build execution instead of crossing invocation boundaries.
+      - name: Run static analysis + build Android app (Debug)
         working-directory: android
-        run: ./gradlew --no-daemon assembleDebug
+        run: ./gradlew --no-daemon --build-cache --configuration-cache staticAnalysis assembleDebug
 
       - name: Rename APK with timestamp + short SHA
         working-directory: android/app/build/outputs/apk/debug/


### PR DESCRIPTION
### Motivation
- Reduce duplicate Gradle invocations in the Android CI job so `staticAnalysis` and `assembleDebug` can share configuration and task outputs in a single execution.

### Description
- Updated `.github/workflows/build-apk.yml` to remove the separate `staticAnalysis` step and run `./gradlew --no-daemon --build-cache --configuration-cache staticAnalysis assembleDebug` in one step after keystore setup, with a short comment explaining the change.

### Testing
- Ran `npm run lint` which exited successfully (lint command completed).
- Ran `scripts/install-android-sdk.sh` which installed the Android SDK (reported at `/opt/android-sdk`).
- Ran `cd android && ./gradlew --no-daemon staticAnalysis` which completed successfully (`BUILD SUCCESSFUL`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999dcfc2a8c8320b389a3f1c2da00ac)