### PR TITLE
Fix podcast queue ID selection for automatic next-track playback

### DIFF
--- a/components/app/AudioPlayerContainer.vue
+++ b/components/app/AudioPlayerContainer.vue
@@ -519,7 +519,7 @@ export default {
           })}`
         })
       }
-      const useServerQueueIds = shouldUseServerIds && !this.isLocalId(libraryItemId)
+      const useServerQueueIds = !this.isLocalId(libraryItemId)
       const startTime = payload.startTime
       const startWhenReady = !payload.paused
 

--- a/store/index.js
+++ b/store/index.js
@@ -9,22 +9,24 @@ function resolveQueueItemIds(item) {
 
   const libraryItem = item.libraryItem || {}
   const libraryItemId =
-    item.localEpisode?.localLibraryItemId ??
-    item.localLibraryItem?.id ??
-    item.localLibraryItemId ??
     item.libraryItemId ??
+    item.serverLibraryItemId ??
     libraryItem.libraryItemId ??
     libraryItem.id ??
+    item.localLibraryItem?.id ??
+    item.localLibraryItemId ??
+    item.localEpisode?.localLibraryItemId ??
     item.id ??
     null
 
   const episode = item.episode || {}
   const episodeId =
-    item.localEpisode?.id ??
-    item.localEpisodeId ??
     item.episodeId ??
+    item.serverEpisodeId ??
     episode.serverEpisodeId ??
     episode.id ??
+    item.localEpisodeId ??
+    item.localEpisode?.id ??
     null
 
   return { libraryItemId, episodeId }


### PR DESCRIPTION
### Motivation
- Auto-advance and now-playing queue behavior for podcasts (including the "unfinished" podcast playlist) was breaking because queue entries were being normalized to local IDs and the native queue payload used inconsistent ID selection, causing queue index misalignment with the native playback session.
- The intent is to preserve server identifiers for server-backed playback and ensure the native queue payload uses server IDs when the active playback target is server-hosted so auto-next logic can resolve the correct next item.

### Description
- Update `resolveQueueItemIds` in `store/index.js` to prioritize `serverLibraryItemId` and `serverEpisodeId` before local identifiers so queue sanitization preserves explicit server IDs when present.
- Change queue payload selection in `components/app/AudioPlayerContainer.vue` so `useServerQueueIds` is derived from whether the active playback `libraryItemId` is a server id (`!this.isLocalId(libraryItemId)`), ensuring native queue payloads use server IDs for server-backed playback.
- These changes keep queue index resolution aligned between the Vuex play queue and the native playback session, restoring correct auto-next behavior for podcasts.

### Testing
- Ran `npm run lint` and it completed successfully with lint checks passing.
- Executed `scripts/install-android-sdk.sh` and it completed successfully (Android SDK installed).
- Ran Android static analysis via `cd android && ./gradlew --no-daemon staticAnalysis` and the build/static analysis completed successfully (BUILD SUCCESSFUL).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999ed373c948320867c05f11bbef622)