### PR TITLE
Player: remove lazyIsPlaying hack, reprepare idle player on play, report playing state on resume

### DIFF
--- a/android/app/src/main/java/com/audiobookshelf/app/player/PlayerListener.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/PlayerListener.kt
@@ -14,7 +14,6 @@ class PlayerListener(var playerNotificationService:PlayerNotificationService) : 
 
   companion object {
     var lastPauseTime: Long = 0   //ms
-    var lazyIsPlaying: Boolean = false
   }
 
   override fun onPlayerError(error: PlaybackException) {
@@ -49,13 +48,6 @@ class PlayerListener(var playerNotificationService:PlayerNotificationService) : 
       Log.d(tag, "onIsPlayingChanged: Pause event when buffering is ignored")
       return
     }
-    if (lazyIsPlaying == isPlaying) {
-      Log.d(tag, "onIsPlayingChanged: Lazy is playing $lazyIsPlaying is already set to this so ignoring")
-      return
-    }
-
-    lazyIsPlaying = isPlaying
-
     // Update widget
     DeviceManager.widgetUpdater?.onPlayerChanged(playerNotificationService)
 

--- a/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/player/PlayerNotificationService.kt
@@ -950,6 +950,15 @@ class PlayerNotificationService : MediaBrowserServiceCompat() {
       Log.d(tag, "Already playing")
       return
     }
+
+    if ((currentPlayer.playbackState == Player.STATE_IDLE || currentPlayer.mediaItemCount == 0) &&
+            currentPlaybackSession != null
+    ) {
+      Log.i(tag, "play: player is idle/unprepared, re-preparing current playback session")
+      preparePlayer(currentPlaybackSession!!.clone(), true, mediaManager.getSavedPlaybackRate())
+      return
+    }
+
     currentPlayer.volume = 1F
     currentPlayer.play()
   }

--- a/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsAudioPlayer.kt
+++ b/android/app/src/main/java/com/audiobookshelf/app/plugins/AbsAudioPlayer.kt
@@ -155,6 +155,7 @@ class AbsAudioPlayer : Plugin() {
     if (::playerNotificationService.isInitialized && playerNotificationService.currentPlaybackSession != null) {
       Handler(Looper.getMainLooper()).postDelayed({
         playerNotificationService.sendClientMetadata(PlayerState.READY)
+        playerNotificationService.clientEventEmitter?.onPlayingUpdate(playerNotificationService.currentPlayer.isPlaying)
         playerNotificationService.sleepTimerManager.sendCurrentSleepTimerState()
         playerNotificationService.mediaProgressSyncer.currentLocalMediaProgress?.let {
           playerNotificationService.clientEventEmitter?.onLocalMediaProgressUpdate(it)
@@ -284,8 +285,6 @@ class AbsAudioPlayer : Plugin() {
           if (playerNotificationService.mediaProgressSyncer.listeningTimerRunning) { // If progress syncing then first stop before preparing next
             playerNotificationService.mediaProgressSyncer.stop {
               Log.d(tag, "Media progress syncer was already syncing - stopped")
-              PlayerListener.lazyIsPlaying = false
-
               Handler(Looper.getMainLooper()).post { // TODO: This was needed again which is probably a design a flaw
                 playerNotificationService.preparePlayer(
                   playbackSession,
@@ -316,7 +315,6 @@ class AbsAudioPlayer : Plugin() {
 
               Handler(Looper.getMainLooper()).post {
                 Log.d(tag, "Preparing Player playback session ${jacksonMapper.writeValueAsString(it)}")
-                PlayerListener.lazyIsPlaying = false
                 playerNotificationService.preparePlayer(it, playWhenReady, playbackRate)
               }
               call.resolve(JSObject(jacksonMapper.writeValueAsString(it)))


### PR DESCRIPTION
### Motivation
- Remove a fragile `lazyIsPlaying` workaround that suppressed legitimate `onIsPlayingChanged` events and caused state desyncs. 
- Ensure `play()` can recover when the player is `STATE_IDLE` or has no media prepared by re-preparing the current playback session. 
- Make sure the UI/client receives the current playing state when the app resumes.

### Description
- Removed the `lazyIsPlaying` flag from `PlayerListener` and eliminated its related checks so `onIsPlayingChanged` events are no longer ignored. 
- In `PlayerNotificationService.play()` added a guard that detects `Player.STATE_IDLE` or empty media and calls `preparePlayer(currentPlaybackSession!!.clone(), true, mediaManager.getSavedPlaybackRate())` when `currentPlaybackSession` is available. 
- In `AbsAudioPlayer.handleOnResume()` added a call to `playerNotificationService.clientEventEmitter?.onPlayingUpdate(playerNotificationService.currentPlayer.isPlaying)` to push playing state to the client after resume. 
- Removed stale assignments to `PlayerListener.lazyIsPlaying` in prepare flows since the flag no longer exists.

### Testing
- Ran the project's Android build (debug) and existing unit tests; they completed successfully. 
- Ran the project's lint/static checks as part of CI; no new warnings were introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f85bb074c8320a26e831d5a814ddd)